### PR TITLE
Improve how hMSBuild is called in the samples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -142,13 +142,13 @@ hMSBuild is a pure batch script. Therefore, you can combine this even inside you
 ```bat
 set msbuild=hMSBuild -notamd64
 ...
-%msbuild% Conari.sln /m:4 /t:Rebuild
+call %msbuild% Conari.sln /m:4 /t:Rebuild
 ```
 
 ```bat
 for /F "tokens=*" %%i in ('hMSBuild -only-path -notamd64') do set msbuild="%%i"
 ...
-%msbuild% /version
+call %msbuild% /version
 ```
 
 ...


### PR DESCRIPTION
The samples how to call `hMSBuild` show to just call the `hMSBuild.bat` file but that calls it `inline` which effectively makes it the last thing to execute in the root `bat` file as the `exit` statements in `hMSBuild.bat` applies to calling (root) `bat` too.
To call another `bat` in an isolated manner one needs to use `call`.

more on this: https://stackoverflow.com/questions/1103994/how-to-run-multiple-bat-files-within-a-bat-file